### PR TITLE
Reduce moneysupply and difficulty value to 0 decimal place

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -73,10 +73,10 @@
                             <strong>Block Height:</strong> {{getInfo.blocks | number:0}}
                         </li>
                         <li>
-                            <strong>Money Supply:</strong> {{getInfo.moneysupply | number:6}}
+                            <strong>Money Supply:</strong> {{getInfo.moneysupply | number:0}}
                         </li>
                         <li>
-                            <strong>Difficulty:</strong> {{getInfo.difficulty | number:8}}
+                            <strong>Difficulty:</strong> {{getInfo.difficulty | number:0}}
                         </li>
                         <li ng-if="getInfo.unlocked_until > 0">
                             Locks {{getInfo.unlocked_until * 1000 | fromNow}}

--- a/public/views/dashboard.html
+++ b/public/views/dashboard.html
@@ -50,7 +50,7 @@
                 Money Supply
             </div>
             <div class="panel-body">
-                <p>{{getInfo.moneysupply | number:6}}</p>
+                <p>{{getInfo.moneysupply | number:0}}</p>
             </div>
         </div>
     </div>
@@ -60,7 +60,7 @@
                 Difficulty
             </div>
             <div class="panel-body">
-                <p>{{getInfo.difficulty | number:8}}</p>
+                <p>{{getInfo.difficulty | number:0}}</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
It was causing weird display issues on smaller screens and would push outside its box when too long. As the values are so high I don’t think it is overly necessary to display these decimal places on the Dashboard or dropdown.
