### PR TITLE
Remove unnecessary brackets

### DIFF
--- a/public/views/address.html
+++ b/public/views/address.html
@@ -2,7 +2,7 @@
     <div class="col-lg-12">
         <div class="panel panel-success">
             <div class="panel-heading">
-                
+
             </div>
             <div class="panel-body">
                 <ul class="list-group list-group-lg no-radius m-b-none m-t-n-xxs">
@@ -30,7 +30,7 @@
                         <div class="clear" ng-if="trans.category == 'receive'">
                             <div><span style="color:#006699"><b>{{trans.amount}} Paycoin</b></span><span class="label bg-light m-l-sm" style="background-color: #006699; color:#ffffff">{{trans.label}}</span></div>
                             <div>
-                                <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>({{trans.account}})<a ui-sref="addressinfo({address:trans.address})">{{ trans.address }}</a></b></div>
+                                <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>{{trans.account}}<a ui-sref="addressinfo({address:trans.address})">{{ trans.address }}</a></b></div>
                             </div>
                         </div>
                         <div class="clear" ng-if="trans.category == 'immature'">

--- a/public/views/dashboard.html
+++ b/public/views/dashboard.html
@@ -134,7 +134,7 @@
                         <div class="clear" ng-if="transaction.category == 'receive'">
                             <div><span style="color:#006699"><b>{{transaction.amount}} Paycoin</b></span><span class="label bg-light m-l-sm" style="background-color: #006699; color:#ffffff">{{transaction.label}}</span></div>
                             <div>
-                                <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>({{transaction.account}})<a ui-sref="addressinfo({address:transaction.address})">{{ transaction.address }}</a></b></div>
+                                <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>{{transaction.account}}<a ui-sref="addressinfo({address:transaction.address})">{{ transaction.address }}</a></b></div>
                             </div>
                         </div>
                         <div class="clear" ng-if="transaction.category == 'immature'">

--- a/public/views/transactions.html
+++ b/public/views/transactions.html
@@ -32,7 +32,7 @@
                                 <div class="clear" ng-if="trans.category == 'receive'">
                                     <div><span style="color:#006699"><b>{{trans.amount}} Paycoin</b></span><span class="label bg-light m-l-sm" style="background-color: #006699; color:#ffffff">{{trans.label}}</span></div>
                                     <div>
-                                        <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>({{trans.account}})<a ui-sref="addressinfo({address:trans.address})">{{ trans.address }}</a></b></div>
+                                        <div class="text-ellipsis m-t-xs"><i>You have received Paycoin at </i><br><b>{{trans.account}}<a ui-sref="addressinfo({address:trans.address})">{{ trans.address }}</a></b></div>
                                     </div>
                                 </div>
                                 <div class="clear" ng-if="trans.category == 'immature'">


### PR DESCRIPTION
This gave me headaches to find, it blended in too well `({{` vs `{{`!

Anywhere we were showing the Paycoin address that received a payment we were placing two brackets `()` before the address. 

Found and exterminated the culprit.

Edit: Sorry I had no addresses with labels but now I see that we were wrapping Address Labels in brackets before the Paycoin Address. I still don't like it because when there is no label you just have two stray brackets. I'm all for removing them but @tvl83 what are your thoughts?
